### PR TITLE
Release v0.3.0 / Add the license entry in the `Cargo.toml`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ documentation = "https://docs.rs/ark-sponge/"
 keywords = [ "zero-knowledge", "cryptography", "zkSNARK", "SNARK", "Poseidon", "sponge" ]
 categories = [ "cryptography" ]
 include = ["Cargo.toml", "src", "README.md", "LICENSE-APACHE", "LICENSE-MIT"]
+license = "MIT/Apache-2.0"
 edition = "2018"
 
 [profile.release]


### PR DESCRIPTION
## Description

`cargo release` reminds us that the license is not being included. This PR fixes so.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Re-reviewed `Files changed` in the Github PR explorer

n/a:
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
