### PR TITLE
Fix Poseidon `random_ark` being too short

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Breaking changes
 
+- [\#21](https://github.com/arkworks-rs/sponge/pull/21) Fix Poseidon `random_ark` being too short.
+
 ### Features
 
 ### Improvements

--- a/src/poseidon/mod.rs
+++ b/src/poseidon/mod.rs
@@ -207,10 +207,10 @@ impl<F: PrimeField> PoseidonParameters<F> {
     }
 
     /// Return a random round constant.
-    pub fn random_ark<R: Rng>(full_rounds: u32, rng: &mut R) -> Vec<Vec<F>> {
+    pub fn random_ark<R: Rng>(full_rounds: u32, partial_rounds: u32, rng: &mut R) -> Vec<Vec<F>> {
         let mut ark = Vec::new();
 
-        for _ in 0..full_rounds {
+        for _ in 0..full_rounds + partial_rounds {
             let mut res = Vec::new();
 
             for _ in 0..3 {


### PR DESCRIPTION
## Description

The Poseidon CRH's `random_ark` function only generates an ARK of length full_rounds * 3, which should be (full_rounds + partial_rounds) * 3.

This PR fixes so.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer

N/A:
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
