### PR TITLE
Traits for Default Poseidon Parameters + Poseidon cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 ### Breaking changes
 
-- [\#21](https://github.com/arkworks-rs/sponge/pull/21) Fix Poseidon `random_ark` being too short.
 - [\#22](https://github.com/arkworks-rs/sponge/pull/22) Clean up the Poseidon parameter and sponge structures.
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,11 @@
 ### Breaking changes
 
 - [\#21](https://github.com/arkworks-rs/sponge/pull/21) Fix Poseidon `random_ark` being too short.
+- [\#22](https://github.com/arkworks-rs/sponge/pull/22) Clean up the Poseidon parameter and sponge structures.
 
 ### Features
+
+- [\#22](https://github.com/arkworks-rs/sponge/pull/22) Add traits and derivations for default Poseidon parameters.
 
 ### Improvements
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ tracing = { version = "0.1", default-features = false, features = [ "attributes"
 
 [dev-dependencies]
 ark-test-curves = { version = "^0.3.0", features = ["bls12_381_curve", "mnt4_753_curve"]}
+num-bigint = "0.4.0"
 
 [features]
 default = [ "r1cs", "std" ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,6 @@ tracing = { version = "0.1", default-features = false, features = [ "attributes"
 
 [dev-dependencies]
 ark-test-curves = { version = "^0.3.0", features = ["bls12_381_curve", "mnt4_753_curve"]}
-num-bigint = "0.4.0"
 
 [features]
 default = [ "r1cs", "std" ]

--- a/src/absorb.rs
+++ b/src/absorb.rs
@@ -377,6 +377,7 @@ mod tests {
     use crate::{batch_field_cast, field_cast};
     use ark_ff::UniformRand;
     use ark_std::test_rng;
+    use ark_std::vec::Vec;
     use ark_test_curves::bls12_381::Fr;
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -197,3 +197,18 @@ pub trait SpongeExt: CryptographicSponge {
     /// Consumes `self` and returns the state.
     fn into_state(self) -> Self::State;
 }
+
+/// The mode structure for duplex sponges
+#[derive(Clone, Debug)]
+pub enum DuplexSpongeMode {
+    /// The sponge is currently absorbing data.
+    Absorbing {
+        /// next position of the state to be XOR-ed when absorbing.
+        next_absorb_index: usize,
+    },
+    /// The sponge is currently squeezing data out.
+    Squeezing {
+        /// next position of the state to be outputted when squeezing.
+        next_squeeze_index: usize,
+    },
+}

--- a/src/poseidon/constraints.rs
+++ b/src/poseidon/constraints.rs
@@ -17,16 +17,16 @@ use ark_std::vec::Vec;
 ///
 /// [cos]: https://eprint.iacr.org/2019/1076
 pub struct PoseidonSpongeVar<F: PrimeField> {
-    /// constraint system
+    /// Constraint system
     pub cs: ConstraintSystemRef<F>,
 
     /// Sponge Parameters
     pub parameters: PoseidonParameters<F>,
 
     // Sponge State
-    /// the sponge's state
+    /// The sponge's state
     pub state: Vec<FpVar<F>>,
-    /// the mode
+    /// The mode
     pub mode: DuplexSpongeMode,
 }
 

--- a/src/poseidon/constraints.rs
+++ b/src/poseidon/constraints.rs
@@ -27,7 +27,7 @@ pub struct PoseidonSpongeVar<F: PrimeField> {
     /// the sponge's state
     pub state: Vec<FpVar<F>>,
     /// the mode
-    mode: DuplexSpongeMode,
+    pub mode: DuplexSpongeMode,
 }
 
 impl<F: PrimeField> PoseidonSpongeVar<F> {

--- a/src/poseidon/grain_lfsr.rs
+++ b/src/poseidon/grain_lfsr.rs
@@ -2,6 +2,7 @@
 
 use ark_ff::{BigInteger, FpParameters, PrimeField};
 use ark_std::cmp::Ordering;
+use ark_std::vec::Vec;
 
 pub struct PoseidonGrainLFSR {
     pub prime_num_bits: u64,

--- a/src/poseidon/grain_lfsr.rs
+++ b/src/poseidon/grain_lfsr.rs
@@ -1,7 +1,6 @@
 #![allow(dead_code)]
 
 use ark_ff::{BigInteger, FpParameters, PrimeField};
-use ark_std::cmp::Ordering;
 use ark_std::vec::Vec;
 
 pub struct PoseidonGrainLFSR {
@@ -147,7 +146,7 @@ impl PoseidonGrainLFSR {
                 .map(|chunk| {
                     let mut result = 0u8;
                     for (i, bit) in chunk.iter().enumerate() {
-                    	result |= u8::from(bit) << i
+                        result |= u8::from(*bit) << i
                     }
                     result
                 })

--- a/src/poseidon/grain_lfsr.rs
+++ b/src/poseidon/grain_lfsr.rs
@@ -1,0 +1,203 @@
+#![allow(dead_code)]
+
+use ark_ff::{BigInteger, FpParameters, PrimeField};
+
+pub struct PoseidonGrainLFSR {
+    pub prime_num_bits: usize,
+
+    pub state: [bool; 80],
+    pub head: usize,
+}
+
+#[allow(unused_variables)]
+impl PoseidonGrainLFSR {
+    pub fn new(
+        is_sbox_an_inverse: bool,
+        prime_num_bits: usize,
+        state_len: usize,
+        num_full_rounds: usize,
+        num_partial_rounds: usize,
+    ) -> Self {
+        let mut state = [false; 80];
+
+        // b0, b1 describes the field
+        state[1] = true;
+
+        // b2, ..., b5 describes the S-BOX
+        if is_sbox_an_inverse {
+            state[5] = true;
+        } else {
+            state[5] = false;
+        }
+
+        // b6, ..., b17 are the binary representation of n (prime_num_bits)
+        {
+            let mut cur = prime_num_bits;
+            for i in (6..=17).rev() {
+                state[i] = cur & 1 == 1;
+                cur >>= 1;
+            }
+        }
+
+        // b18, ..., b29 are the binary representation of t (state_len, rate + capacity)
+        {
+            let mut cur = state_len;
+            for i in (18..=29).rev() {
+                state[i] = cur & 1 == 1;
+                cur >>= 1;
+            }
+        }
+
+        // b30, ..., b39 are the binary representation of R_F (the number of full rounds)
+        {
+            let mut cur = num_full_rounds;
+            for i in (30..=39).rev() {
+                state[i] = cur & 1 == 1;
+                cur >>= 1;
+            }
+        }
+
+        // b40, ..., b49 are the binary representation of R_P (the number of partial rounds)
+        {
+            let mut cur = num_partial_rounds;
+            for i in (40..=49).rev() {
+                state[i] = cur & 1 == 1;
+                cur >>= 1;
+            }
+        }
+
+        // b50, ..., b79 are set to 1
+        for i in 50..=79 {
+            state[i] = true;
+        }
+
+        println!(
+            "state: {:?}",
+            state
+                .iter()
+                .map(|x| {
+                    if *x {
+                        1
+                    } else {
+                        0
+                    }
+                })
+                .collect::<Vec<u64>>()
+        );
+
+        let head = 0;
+
+        let mut res = Self {
+            prime_num_bits,
+            state,
+            head,
+        };
+        res.init();
+        res
+    }
+
+    pub fn get_bits(&mut self, num_bits: usize) -> Vec<bool> {
+        let mut res = Vec::new();
+
+        for _ in 0..num_bits {
+            // Obtain the first bit
+            let mut new_bit = self.update();
+
+            // Loop until the first bit is true
+            while new_bit == false {
+                // Discard the second bit
+                let _ = self.update();
+                // Obtain another first bit
+                new_bit = self.update();
+            }
+
+            // Obtain the second bit
+            res.push(self.update());
+        }
+
+        res
+    }
+
+    pub fn get_field_elements<F: PrimeField>(&mut self, num_elems: usize) -> Vec<F> {
+        assert_eq!(F::Params::MODULUS_BITS as usize, self.prime_num_bits);
+
+        let mut res = Vec::new();
+        for _ in 0..num_elems {
+            // Perform rejection sampling
+            loop {
+                // Obtain n bits and make it most-significant-bit first
+                let mut bits = self.get_bits(self.prime_num_bits);
+                bits.reverse();
+
+                // Construct the number
+                let bigint = F::BigInt::from_bits_le(&bits);
+
+                // Check if bigint >= MODULUS, if so, reject and resample
+                let field_elem = F::from_repr(bigint);
+
+                if field_elem.is_some() {
+                    res.push(field_elem.unwrap());
+                    break;
+                }
+            }
+        }
+
+        res
+    }
+
+    #[inline]
+    fn update(&mut self) -> bool {
+        let new_bit = self.state[(self.head + 62) % 80]
+            ^ self.state[(self.head + 51) % 80]
+            ^ self.state[(self.head + 38) % 80]
+            ^ self.state[(self.head + 23) % 80]
+            ^ self.state[(self.head + 13) % 80]
+            ^ self.state[self.head];
+        self.state[self.head] = new_bit;
+        self.head += 1;
+        self.head %= 80;
+
+        new_bit
+    }
+
+    fn init(&mut self) {
+        for _ in 0..160 {
+            let new_bit = self.state[(self.head + 62) % 80]
+                ^ self.state[(self.head + 51) % 80]
+                ^ self.state[(self.head + 38) % 80]
+                ^ self.state[(self.head + 23) % 80]
+                ^ self.state[(self.head + 13) % 80]
+                ^ self.state[self.head];
+            self.state[self.head] = new_bit;
+            self.head += 1;
+            self.head %= 80;
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::poseidon::grain_lfsr::PoseidonGrainLFSR;
+    use ark_ff::field_new;
+    use ark_test_curves::bls12_381::Fr;
+
+    #[test]
+    fn test_grain_lfsr_consistency() {
+        let mut lfsr = PoseidonGrainLFSR::new(false, 255, 3, 8, 31);
+
+        assert_eq!(
+            lfsr.get_field_elements::<Fr>(1)[0],
+            field_new!(
+                Fr,
+                "27117311055620256798560880810000042840428971800021819916023577129547249660720"
+            )
+        );
+        assert_eq!(
+            lfsr.get_field_elements::<Fr>(1)[0],
+            field_new!(
+                Fr,
+                "51641662388546346858987925410984003801092143452466182801674685248597955169158"
+            )
+        );
+    }
+}

--- a/src/poseidon/mod.rs
+++ b/src/poseidon/mod.rs
@@ -23,20 +23,20 @@ mod grain_lfsr;
 #[derive(Clone, Debug)]
 pub struct PoseidonParameters<F: PrimeField> {
     /// number of rounds in a full-round operation
-    full_rounds: usize,
+    pub full_rounds: usize,
     /// number of rounds in a partial-round operation
-    partial_rounds: usize,
+    pub partial_rounds: usize,
     /// Exponent used in S-boxes
-    alpha: u64,
+    pub alpha: u64,
     /// Additive Round keys. These are added before each MDS matrix application to make it an affine shift.
     /// They are indexed by `ark[round_num][state_element_index]`
-    ark: Vec<Vec<F>>,
+    pub ark: Vec<Vec<F>>,
     /// Maximally Distance Separating Matrix.
-    mds: Vec<Vec<F>>,
+    pub mds: Vec<Vec<F>>,
     /// the rate (in terms of number of field elements)
-    rate: usize,
+    pub rate: usize,
     /// the capacity (in terms of number of field elements)
-    capacity: usize,
+    pub capacity: usize,
 }
 
 #[derive(Clone)]

--- a/src/poseidon/mod.rs
+++ b/src/poseidon/mod.rs
@@ -22,11 +22,11 @@ mod grain_lfsr;
 /// Parameters and RNG used
 #[derive(Clone, Debug)]
 pub struct PoseidonParameters<F: PrimeField> {
-    /// Number of rounds in a full-round operation
+    /// Number of rounds in a full-round operation.
     pub full_rounds: usize,
-    /// Number of rounds in a partial-round operation
+    /// Number of rounds in a partial-round operation.
     pub partial_rounds: usize,
-    /// Exponent used in S-boxes
+    /// Exponent used in S-boxes.
     pub alpha: u64,
     /// Additive Round keys. These are added before each MDS matrix application to make it an affine shift.
     /// They are indexed by `ark[round_num][state_element_index]`
@@ -37,7 +37,7 @@ pub struct PoseidonParameters<F: PrimeField> {
     /// See [On the Indifferentiability of the Sponge Construction](https://iacr.org/archive/eurocrypt2008/49650180/49650180.pdf)
     /// for more details on the rate and capacity of a sponge.
     pub rate: usize,
-    /// The capacity (in terms of number of field elements)
+    /// The capacity (in terms of number of field elements).
     pub capacity: usize,
 }
 

--- a/src/poseidon/mod.rs
+++ b/src/poseidon/mod.rs
@@ -49,13 +49,13 @@ pub struct PoseidonParameters<F: PrimeField> {
 ///
 /// [cos]: https://eprint.iacr.org/2019/1076
 pub struct PoseidonSponge<F: PrimeField> {
-    // Sponge Parameters
+    /// Sponge Parameters
     pub parameters: PoseidonParameters<F>,
 
     // Sponge State
-    /// current sponge's state (current elements in the permutation block)
+    /// Current sponge's state (current elements in the permutation block)
     pub state: Vec<F>,
-    /// current mode (whether its absorbing or squeezing)
+    /// Current mode (whether its absorbing or squeezing)
     pub mode: DuplexSpongeMode,
 }
 

--- a/src/poseidon/mod.rs
+++ b/src/poseidon/mod.rs
@@ -50,13 +50,13 @@ pub struct PoseidonParameters<F: PrimeField> {
 /// [cos]: https://eprint.iacr.org/2019/1076
 pub struct PoseidonSponge<F: PrimeField> {
     // Sponge Parameters
-    parameters: PoseidonParameters<F>,
+    pub parameters: PoseidonParameters<F>,
 
     // Sponge State
     /// current sponge's state (current elements in the permutation block)
-    state: Vec<F>,
+    pub state: Vec<F>,
     /// current mode (whether its absorbing or squeezing)
-    mode: DuplexSpongeMode,
+    pub mode: DuplexSpongeMode,
 }
 
 impl<F: PrimeField> PoseidonSponge<F> {

--- a/src/poseidon/mod.rs
+++ b/src/poseidon/mod.rs
@@ -17,6 +17,8 @@ mod tests;
 pub mod traits;
 pub use traits::*;
 
+mod grain_lfsr;
+
 /// Parameters and RNG used
 #[derive(Clone, Debug)]
 pub struct PoseidonParameters<F: PrimeField> {

--- a/src/poseidon/mod.rs
+++ b/src/poseidon/mod.rs
@@ -33,9 +33,11 @@ pub struct PoseidonParameters<F: PrimeField> {
     pub ark: Vec<Vec<F>>,
     /// Maximally Distance Separating (MDS) Matrix.
     pub mds: Vec<Vec<F>>,
-    /// the rate (in terms of number of field elements)
+    /// The rate (in terms of number of field elements).
+    /// See [On the Indifferentiability of the Sponge Construction](https://iacr.org/archive/eurocrypt2008/49650180/49650180.pdf)
+    /// for more details on
     pub rate: usize,
-    /// the capacity (in terms of number of field elements)
+    /// The capacity (in terms of number of field elements).
     pub capacity: usize,
 }
 
@@ -366,7 +368,7 @@ impl<CF: PrimeField> SpongeExt for PoseidonSponge<CF> {
 
 #[cfg(test)]
 mod test {
-    use crate::poseidon::{PoseidonDefaultParameters, PoseidonDefaultParametersField};
+    use crate::poseidon::{PoseidonDefaultParameters, PoseidonDefaultParametersField, PoseidonDefaultParametersEntry};
     use crate::{poseidon::PoseidonSponge, CryptographicSponge, FieldBasedCryptographicSponge};
     use ark_ff::{field_new, BigInteger256, FftParameters, Fp256, Fp256Parameters, FpParameters};
     use ark_test_curves::bls12_381::FrParameters;
@@ -397,23 +399,23 @@ mod test {
     }
 
     impl PoseidonDefaultParameters for TestFrParameters {
-        const PARAMS_OPT_FOR_CONSTRAINTS: [[usize; 5]; 7] = [
-            [2, 17, 8, 31, 0],
-            [3, 5, 8, 56, 0],
-            [4, 5, 8, 56, 0],
-            [5, 5, 8, 57, 0],
-            [6, 5, 8, 57, 0],
-            [7, 5, 8, 57, 0],
-            [8, 5, 8, 57, 0],
+        const PARAMS_OPT_FOR_CONSTRAINTS: [PoseidonDefaultParametersEntry; 7] = [
+            PoseidonDefaultParametersEntry::new(2, 17, 8, 31, 0),
+            PoseidonDefaultParametersEntry::new(3, 5, 8, 56, 0),
+            PoseidonDefaultParametersEntry::new(4, 5, 8, 56, 0),
+            PoseidonDefaultParametersEntry::new(5, 5, 8, 57, 0),
+            PoseidonDefaultParametersEntry::new(6, 5, 8, 57, 0),
+            PoseidonDefaultParametersEntry::new(7, 5, 8, 57, 0),
+            PoseidonDefaultParametersEntry::new(8, 5, 8, 57, 0),
         ];
-        const PARAMS_OPT_FOR_WEIGHTS: [[usize; 5]; 7] = [
-            [2, 257, 8, 13, 0],
-            [3, 257, 8, 13, 0],
-            [4, 257, 8, 13, 0],
-            [5, 257, 8, 13, 0],
-            [6, 257, 8, 13, 0],
-            [7, 257, 8, 13, 0],
-            [8, 257, 8, 13, 0],
+        const PARAMS_OPT_FOR_WEIGHTS: [PoseidonDefaultParametersEntry; 7] = [
+            PoseidonDefaultParametersEntry::new(2, 257, 8, 13, 0),
+            PoseidonDefaultParametersEntry::new(3, 257, 8, 13, 0),
+            PoseidonDefaultParametersEntry::new(4, 257, 8, 13, 0),
+            PoseidonDefaultParametersEntry::new(5, 257, 8, 13, 0),
+            PoseidonDefaultParametersEntry::new(6, 257, 8, 13, 0),
+            PoseidonDefaultParametersEntry::new(7, 257, 8, 13, 0),
+            PoseidonDefaultParametersEntry::new(8, 257, 8, 13, 0),
         ];
     }
 

--- a/src/poseidon/tests.rs
+++ b/src/poseidon/tests.rs
@@ -805,11 +805,15 @@ pub(crate) fn poseidon_parameters_for_test<F: PrimeField>() -> PoseidonParameter
     let full_rounds = 8;
     let total_rounds = 37;
     let partial_rounds = total_rounds - full_rounds;
+    let capacity = 1;
+    let rate = 2;
     PoseidonParameters {
         full_rounds,
         partial_rounds,
         alpha,
         ark,
         mds,
+        rate,
+        capacity,
     }
 }

--- a/src/poseidon/traits.rs
+++ b/src/poseidon/traits.rs
@@ -1,0 +1,64 @@
+use crate::poseidon::PoseidonParameters;
+use ark_ff::{fields::models::*, FpParameters, PrimeField};
+use ark_relations::r1cs::OptimizationGoal;
+
+/// A trait for default Poseidon parameters associated with a prime field
+pub trait PoseidonDefaultParameters: FpParameters {
+    /// An array of the parameters optimized for constraints
+    /// (rate, alpha, full_rounds, partial_rounds)
+    /// for rate = 2, 3, 4, 5, 6, 7, 8
+    const PARAMS_OPT_FOR_CONSTRAINTS: [[usize; 4]; 7];
+    /* example
+    ```
+    [
+        [2, 3, 8, 31],
+        [3, 3, 8, 31],
+        [4, 3, 8, 31],
+        [5, 3, 8, 31],
+        [6, 3, 8, 31],
+        [7, 3, 8, 31],
+        [8, 3, 8, 31],
+    ]
+    ```
+    */
+
+    /// An array of the parameters optimized for weights
+    /// (rate, alpha, full_rounds, partial_rounds)
+    /// for rate = 2, 3, 4, 5, 6, 7, 8
+    const PARAMS_OPT_FOR_WEIGHTS: [[usize; 4]; 7];
+
+    /// A Grain PRNG seed that has been tested to generate
+    /// good matrices for all the cases above
+    const GRAIN_PRNG_SEED: [u8; 10];
+}
+
+/// A field with Poseidon parameters associated
+pub trait PoseidonDefaultParametersField: PrimeField {
+    /// Obtain the default Poseidon parameters for this rate and for this prime field,
+    /// with a specific optimization goal.
+    fn default_poseidon_parameters(
+        rate: u64,
+        optimization_goal: OptimizationGoal,
+    ) -> PoseidonParameters<Self>;
+}
+
+macro_rules! impl_poseidon_default_parameters_field {
+    ($field: ident, $params: ident) => {
+        impl<P: $params + PoseidonDefaultParameters> PoseidonDefaultParametersField for $field<P> {
+            fn default_poseidon_parameters(
+                _rate: u64,
+                _optimization_goal: OptimizationGoal,
+            ) -> PoseidonParameters<Self> {
+                unimplemented!()
+            }
+        }
+    };
+}
+
+impl_poseidon_default_parameters_field!(Fp64, Fp64Parameters);
+impl_poseidon_default_parameters_field!(Fp256, Fp256Parameters);
+impl_poseidon_default_parameters_field!(Fp320, Fp320Parameters);
+impl_poseidon_default_parameters_field!(Fp384, Fp384Parameters);
+impl_poseidon_default_parameters_field!(Fp448, Fp448Parameters);
+impl_poseidon_default_parameters_field!(Fp768, Fp768Parameters);
+impl_poseidon_default_parameters_field!(Fp832, Fp832Parameters);

--- a/src/poseidon/traits.rs
+++ b/src/poseidon/traits.rs
@@ -23,7 +23,10 @@ pub trait PoseidonDefaultParameters: FpParameters {
 pub trait PoseidonDefaultParametersField: PrimeField {
     /// Obtain the default Poseidon parameters for this rate and for this prime field,
     /// with a specific optimization goal.
-    fn get_default_poseidon_parameters(rate: usize, optimized_for_weights: bool) -> Option<PoseidonParameters<Self>>;
+    fn get_default_poseidon_parameters(
+        rate: usize,
+        optimized_for_weights: bool,
+    ) -> Option<PoseidonParameters<Self>>;
 }
 
 /// Internal function that uses the `PoseidonDefaultParameters` to compute the Poseidon parameters.
@@ -70,7 +73,13 @@ pub fn find_poseidon_ark_and_mds<F: PrimeField>(
     partial_rounds: u64,
     skip_matrices: u64,
 ) -> (Vec<Vec<F>>, Vec<Vec<F>>) {
-    let mut lfsr = PoseidonGrainLFSR::new(false, prime_bits, (rate + 1) as u64, full_rounds, partial_rounds);
+    let mut lfsr = PoseidonGrainLFSR::new(
+        false,
+        prime_bits,
+        (rate + 1) as u64,
+        full_rounds,
+        partial_rounds,
+    );
 
     let mut ark = Vec::<Vec<F>>::new();
     for _ in 0..(full_rounds + partial_rounds) {
@@ -103,7 +112,10 @@ pub fn find_poseidon_ark_and_mds<F: PrimeField>(
 macro_rules! impl_poseidon_default_parameters_field {
     ($field: ident, $params: ident) => {
         impl<P: $params + PoseidonDefaultParameters> PoseidonDefaultParametersField for $field<P> {
-            fn get_default_parameters(rate: usize, optimized_for_weights: bool) -> Option<PoseidonParameters<Self>> {
+            fn get_default_poseidon_parameters(
+                rate: usize,
+                optimized_for_weights: bool,
+            ) -> Option<PoseidonParameters<Self>> {
                 get_default_poseidon_parameters_internal::<Self, P>(rate, optimized_for_weights)
             }
         }
@@ -176,7 +188,7 @@ mod test {
     #[test]
     fn bls12_381_fr_poseidon_default_parameters_test() {
         // constraints
-        let constraints_rate_2 = TestFr::get_default_parameters(2, false).unwrap();
+        let constraints_rate_2 = TestFr::get_default_poseidon_parameters(2, false).unwrap();
         assert_eq!(
             constraints_rate_2.ark[0][0],
             field_new!(
@@ -192,7 +204,7 @@ mod test {
             )
         );
 
-        let constraints_rate_3 = TestFr::get_default_parameters(3, false).unwrap();
+        let constraints_rate_3 = TestFr::get_default_poseidon_parameters(3, false).unwrap();
         assert_eq!(
             constraints_rate_3.ark[0][0],
             field_new!(
@@ -208,7 +220,7 @@ mod test {
             )
         );
 
-        let constraints_rate_4 = TestFr::get_default_parameters(4, false).unwrap();
+        let constraints_rate_4 = TestFr::get_default_poseidon_parameters(4, false).unwrap();
         assert_eq!(
             constraints_rate_4.ark[0][0],
             field_new!(
@@ -224,7 +236,7 @@ mod test {
             )
         );
 
-        let constraints_rate_5 = TestFr::get_default_parameters(5, false).unwrap();
+        let constraints_rate_5 = TestFr::get_default_poseidon_parameters(5, false).unwrap();
         assert_eq!(
             constraints_rate_5.ark[0][0],
             field_new!(
@@ -240,7 +252,7 @@ mod test {
             )
         );
 
-        let constraints_rate_6 = TestFr::get_default_parameters(6, false).unwrap();
+        let constraints_rate_6 = TestFr::get_default_poseidon_parameters(6, false).unwrap();
         assert_eq!(
             constraints_rate_6.ark[0][0],
             field_new!(
@@ -256,7 +268,7 @@ mod test {
             )
         );
 
-        let constraints_rate_7 = TestFr::get_default_parameters(7, false).unwrap();
+        let constraints_rate_7 = TestFr::get_default_poseidon_parameters(7, false).unwrap();
         assert_eq!(
             constraints_rate_7.ark[0][0],
             field_new!(
@@ -272,7 +284,7 @@ mod test {
             )
         );
 
-        let constraints_rate_8 = TestFr::get_default_parameters(8, false).unwrap();
+        let constraints_rate_8 = TestFr::get_default_poseidon_parameters(8, false).unwrap();
         assert_eq!(
             constraints_rate_8.ark[0][0],
             field_new!(
@@ -289,7 +301,7 @@ mod test {
         );
 
         // weights
-        let weights_rate_2 = TestFr::get_default_parameters(2, true).unwrap();
+        let weights_rate_2 = TestFr::get_default_poseidon_parameters(2, true).unwrap();
         assert_eq!(
             weights_rate_2.ark[0][0],
             field_new!(
@@ -305,7 +317,7 @@ mod test {
             )
         );
 
-        let weights_rate_3 = TestFr::get_default_parameters(3, true).unwrap();
+        let weights_rate_3 = TestFr::get_default_poseidon_parameters(3, true).unwrap();
         assert_eq!(
             weights_rate_3.ark[0][0],
             field_new!(
@@ -321,7 +333,7 @@ mod test {
             )
         );
 
-        let weights_rate_4 = TestFr::get_default_parameters(4, true).unwrap();
+        let weights_rate_4 = TestFr::get_default_poseidon_parameters(4, true).unwrap();
         assert_eq!(
             weights_rate_4.ark[0][0],
             field_new!(
@@ -337,7 +349,7 @@ mod test {
             )
         );
 
-        let weights_rate_5 = TestFr::get_default_parameters(5, true).unwrap();
+        let weights_rate_5 = TestFr::get_default_poseidon_parameters(5, true).unwrap();
         assert_eq!(
             weights_rate_5.ark[0][0],
             field_new!(
@@ -353,7 +365,7 @@ mod test {
             )
         );
 
-        let weights_rate_6 = TestFr::get_default_parameters(6, true).unwrap();
+        let weights_rate_6 = TestFr::get_default_poseidon_parameters(6, true).unwrap();
         assert_eq!(
             weights_rate_6.ark[0][0],
             field_new!(
@@ -369,7 +381,7 @@ mod test {
             )
         );
 
-        let weights_rate_7 = TestFr::get_default_parameters(7, true).unwrap();
+        let weights_rate_7 = TestFr::get_default_poseidon_parameters(7, true).unwrap();
         assert_eq!(
             weights_rate_7.ark[0][0],
             field_new!(
@@ -385,7 +397,7 @@ mod test {
             )
         );
 
-        let weights_rate_8 = TestFr::get_default_parameters(8, true).unwrap();
+        let weights_rate_8 = TestFr::get_default_poseidon_parameters(8, true).unwrap();
         assert_eq!(
             weights_rate_8.ark[0][0],
             field_new!(

--- a/src/poseidon/traits.rs
+++ b/src/poseidon/traits.rs
@@ -139,7 +139,6 @@ mod test {
     use ark_ff::{BigInteger256, FftParameters, Fp256Parameters, FpParameters, PrimeField};
     use ark_relations::r1cs::OptimizationGoal;
     use ark_test_curves::bls12_381::FrParameters;
-    use num_bigint::BigUint;
 
     pub struct TestFrParameters;
 

--- a/src/poseidon/traits.rs
+++ b/src/poseidon/traits.rs
@@ -1,3 +1,4 @@
+use crate::poseidon::grain_lfsr::PoseidonGrainLFSR;
 use crate::poseidon::PoseidonParameters;
 use ark_ff::{fields::models::*, FpParameters, PrimeField};
 use ark_relations::r1cs::OptimizationGoal;
@@ -5,51 +6,119 @@ use ark_relations::r1cs::OptimizationGoal;
 /// A trait for default Poseidon parameters associated with a prime field
 pub trait PoseidonDefaultParameters: FpParameters {
     /// An array of the parameters optimized for constraints
-    /// (rate, alpha, full_rounds, partial_rounds)
+    /// (rate, alpha, full_rounds, partial_rounds, skip_matrices)
     /// for rate = 2, 3, 4, 5, 6, 7, 8
-    const PARAMS_OPT_FOR_CONSTRAINTS: [[usize; 4]; 7];
-    /* example
-    ```
-    [
-        [2, 3, 8, 31],
-        [3, 3, 8, 31],
-        [4, 3, 8, 31],
-        [5, 3, 8, 31],
-        [6, 3, 8, 31],
-        [7, 3, 8, 31],
-        [8, 3, 8, 31],
-    ]
-    ```
-    */
+    ///
+    /// Here, `skip_matrices` denote how many matrices to skip before
+    /// finding one that satisfy all the requirements.
+    const PARAMS_OPT_FOR_CONSTRAINTS: [[usize; 5]; 7];
 
     /// An array of the parameters optimized for weights
-    /// (rate, alpha, full_rounds, partial_rounds)
+    /// (rate, alpha, full_rounds, partial_rounds, skip_matrices)
     /// for rate = 2, 3, 4, 5, 6, 7, 8
-    const PARAMS_OPT_FOR_WEIGHTS: [[usize; 4]; 7];
-
-    /// A Grain PRNG seed that has been tested to generate
-    /// good matrices for all the cases above
-    const GRAIN_PRNG_SEED: [u8; 10];
+    const PARAMS_OPT_FOR_WEIGHTS: [[usize; 5]; 7];
 }
 
 /// A field with Poseidon parameters associated
 pub trait PoseidonDefaultParametersField: PrimeField {
     /// Obtain the default Poseidon parameters for this rate and for this prime field,
     /// with a specific optimization goal.
-    fn default_poseidon_parameters(
-        rate: u64,
+    fn get_default_parameters(
+        rate: usize,
         optimization_goal: OptimizationGoal,
-    ) -> PoseidonParameters<Self>;
+    ) -> Option<PoseidonParameters<Self>>;
+
+    /// Internal function that uses the `PoseidonDefaultParameters` to compute the Poseidon parameters.
+    fn get_default_parameters_internal<P: PoseidonDefaultParameters>(
+        rate: usize,
+        optimization_goal: OptimizationGoal,
+    ) -> Option<PoseidonParameters<Self>> {
+        let params_set = if optimization_goal == OptimizationGoal::Constraints
+            || optimization_goal == OptimizationGoal::None
+        {
+            P::PARAMS_OPT_FOR_CONSTRAINTS
+        } else {
+            P::PARAMS_OPT_FOR_WEIGHTS
+        };
+
+        for param in params_set.iter() {
+            if param[0] == rate {
+                let (ark, mds) = Self::find_ark_and_mds(
+                    P::MODULUS_BITS as u64,
+                    rate,
+                    param[2] as u64,
+                    param[3] as u64,
+                    param[4] as u64,
+                );
+
+                return Some(PoseidonParameters {
+                    full_rounds: param[2],
+                    partial_rounds: param[3],
+                    alpha: param[1] as u64,
+                    ark: ark,
+                    mds: mds,
+                    rate: param[0],
+                    capacity: 1,
+                });
+            }
+        }
+
+        None
+    }
+
+    /// Internal function that computes the ark and mds from the Poseidon Grain LFSR.
+    fn find_ark_and_mds(
+        prime_bits: u64,
+        rate: usize,
+        full_rounds: u64,
+        partial_rounds: u64,
+        skip_matrices: u64,
+    ) -> (Vec<Vec<Self>>, Vec<Vec<Self>>) {
+        let mut lfsr = PoseidonGrainLFSR::new(
+            false,
+            prime_bits,
+            (rate + 1) as u64,
+            full_rounds,
+            partial_rounds,
+        );
+
+        let mut ark = Vec::<Vec<Self>>::new();
+        for _ in 0..(full_rounds + partial_rounds) {
+            ark.push(lfsr.get_field_elements_rejection_sampling(rate + 1));
+        }
+
+        let mut mds = Vec::<Vec<Self>>::new();
+        mds.resize(rate + 1, vec![Self::zero(); rate + 1]);
+        for _ in 0..skip_matrices {
+            let _ = lfsr.get_field_elements_mod_p::<Self>(2 * (rate + 1));
+        }
+
+        // a qualifying matrix must satisfy the following requirements
+        // - there is no duplication among the elements in x or y
+        // - there is no i and j such that x[i] + y[j] = p
+        // - the resultant MDS passes all the three tests
+
+        let xs = lfsr.get_field_elements_mod_p::<Self>(rate + 1);
+        let ys = lfsr.get_field_elements_mod_p::<Self>(rate + 1);
+
+        for i in 0..(rate + 1) {
+            for j in 0..(rate + 1) {
+                mds[i][j] = (xs[i] + &ys[j]).inverse().unwrap();
+            }
+        }
+
+        (ark, mds)
+    }
 }
 
 macro_rules! impl_poseidon_default_parameters_field {
     ($field: ident, $params: ident) => {
         impl<P: $params + PoseidonDefaultParameters> PoseidonDefaultParametersField for $field<P> {
-            fn default_poseidon_parameters(
-                _rate: u64,
-                _optimization_goal: OptimizationGoal,
-            ) -> PoseidonParameters<Self> {
-                unimplemented!()
+            fn get_default_parameters(
+                rate: usize,
+                optimization_goal: OptimizationGoal,
+            ) -> Option<PoseidonParameters<Self>> {
+                Self::get_default_parameters_internal::<P>(rate, optimization_goal)
             }
         }
     };
@@ -62,3 +131,297 @@ impl_poseidon_default_parameters_field!(Fp384, Fp384Parameters);
 impl_poseidon_default_parameters_field!(Fp448, Fp448Parameters);
 impl_poseidon_default_parameters_field!(Fp768, Fp768Parameters);
 impl_poseidon_default_parameters_field!(Fp832, Fp832Parameters);
+
+#[cfg(test)]
+mod test {
+    use crate::poseidon::{PoseidonDefaultParameters, PoseidonDefaultParametersField};
+    use ark_ff::{field_new, fields::Fp256};
+    use ark_ff::{BigInteger256, FftParameters, Fp256Parameters, FpParameters, PrimeField};
+    use ark_relations::r1cs::OptimizationGoal;
+    use ark_test_curves::bls12_381::FrParameters;
+    use num_bigint::BigUint;
+
+    pub struct TestFrParameters;
+
+    impl Fp256Parameters for TestFrParameters {}
+    impl FftParameters for TestFrParameters {
+        type BigInt = <FrParameters as FftParameters>::BigInt;
+        const TWO_ADICITY: u32 = FrParameters::TWO_ADICITY;
+        const TWO_ADIC_ROOT_OF_UNITY: Self::BigInt = FrParameters::TWO_ADIC_ROOT_OF_UNITY;
+    }
+
+    // This TestFrParameters is the same as the BLS12-381's Fr.
+    // MODULUS = 52435875175126190479447740508185965837690552500527637822603658699938581184513
+    impl FpParameters for TestFrParameters {
+        const MODULUS: BigInteger256 = FrParameters::MODULUS;
+        const MODULUS_BITS: u32 = FrParameters::MODULUS_BITS;
+        const CAPACITY: u32 = FrParameters::CAPACITY;
+        const REPR_SHAVE_BITS: u32 = FrParameters::REPR_SHAVE_BITS;
+        const R: BigInteger256 = FrParameters::R;
+        const R2: BigInteger256 = FrParameters::R2;
+        const INV: u64 = FrParameters::INV;
+        const GENERATOR: BigInteger256 = FrParameters::GENERATOR;
+        const MODULUS_MINUS_ONE_DIV_TWO: BigInteger256 = FrParameters::MODULUS_MINUS_ONE_DIV_TWO;
+        const T: BigInteger256 = FrParameters::T;
+        const T_MINUS_ONE_DIV_TWO: BigInteger256 = FrParameters::T_MINUS_ONE_DIV_TWO;
+    }
+
+    impl PoseidonDefaultParameters for TestFrParameters {
+        const PARAMS_OPT_FOR_CONSTRAINTS: [[usize; 5]; 7] = [
+            [2, 17, 8, 31, 0],
+            [3, 5, 8, 56, 0],
+            [4, 5, 8, 56, 0],
+            [5, 5, 8, 57, 0],
+            [6, 5, 8, 57, 0],
+            [7, 5, 8, 57, 0],
+            [8, 5, 8, 57, 0],
+        ];
+        const PARAMS_OPT_FOR_WEIGHTS: [[usize; 5]; 7] = [
+            [2, 257, 8, 13, 0],
+            [3, 257, 8, 13, 0],
+            [4, 257, 8, 13, 0],
+            [5, 257, 8, 13, 0],
+            [6, 257, 8, 13, 0],
+            [7, 257, 8, 13, 0],
+            [8, 257, 8, 13, 0],
+        ];
+    }
+
+    pub type TestFr = Fp256<TestFrParameters>;
+
+    #[test]
+    fn bls12_381_fr_poseidon_default_parameters_test() {
+        // constraints
+        let constraints_rate_2 =
+            TestFr::get_default_parameters(2, OptimizationGoal::Constraints).unwrap();
+        assert_eq!(
+            constraints_rate_2.ark[0][0],
+            field_new!(
+                TestFr,
+                "27117311055620256798560880810000042840428971800021819916023577129547249660720"
+            )
+        );
+        assert_eq!(
+            constraints_rate_2.mds[0][0],
+            field_new!(
+                TestFr,
+                "26017457457808754696901916760153646963713419596921330311675236858336250747575"
+            )
+        );
+
+        let constraints_rate_3 =
+            TestFr::get_default_parameters(3, OptimizationGoal::Constraints).unwrap();
+        assert_eq!(
+            constraints_rate_3.ark[0][0],
+            field_new!(
+                TestFr,
+                "11865901593870436687704696210307853465124332568266803587887584059192277437537"
+            )
+        );
+        assert_eq!(
+            constraints_rate_3.mds[0][0],
+            field_new!(
+                TestFr,
+                "18791275321793747281053101601584820964683215017313972132092847596434094368732"
+            )
+        );
+
+        let constraints_rate_4 =
+            TestFr::get_default_parameters(4, OptimizationGoal::Constraints).unwrap();
+        assert_eq!(
+            constraints_rate_4.ark[0][0],
+            field_new!(
+                TestFr,
+                "41775194144383840477168997387904574072980173775424253289429546852163474914621"
+            )
+        );
+        assert_eq!(
+            constraints_rate_4.mds[0][0],
+            field_new!(
+                TestFr,
+                "42906651709148432559075674119637355642263148226238482628104108168707874713729"
+            )
+        );
+
+        let constraints_rate_5 =
+            TestFr::get_default_parameters(5, OptimizationGoal::Constraints).unwrap();
+        assert_eq!(
+            constraints_rate_5.ark[0][0],
+            field_new!(
+                TestFr,
+                "24877380261526996562448766783081897666376381975344509826094208368479247894723"
+            )
+        );
+        assert_eq!(
+            constraints_rate_5.mds[0][0],
+            field_new!(
+                TestFr,
+                "30022080821787948421423927053079656488514459012053372877891553084525866347732"
+            )
+        );
+
+        let constraints_rate_6 =
+            TestFr::get_default_parameters(6, OptimizationGoal::Constraints).unwrap();
+        assert_eq!(
+            constraints_rate_6.ark[0][0],
+            field_new!(
+                TestFr,
+                "37928506567864057383105673253383925733025682403141583234734361541053005808936"
+            )
+        );
+        assert_eq!(
+            constraints_rate_6.mds[0][0],
+            field_new!(
+                TestFr,
+                "49124738641420159156404016903087065194698370461819821829905285681776084204443"
+            )
+        );
+
+        let constraints_rate_7 =
+            TestFr::get_default_parameters(7, OptimizationGoal::Constraints).unwrap();
+        assert_eq!(
+            constraints_rate_7.ark[0][0],
+            field_new!(
+                TestFr,
+                "37848764121158464546907147011864524711588624175161409526679215525602690343051"
+            )
+        );
+        assert_eq!(
+            constraints_rate_7.mds[0][0],
+            field_new!(
+                TestFr,
+                "28113878661515342855868752866874334649815072505130059513989633785080391114646"
+            )
+        );
+
+        let constraints_rate_8 =
+            TestFr::get_default_parameters(8, OptimizationGoal::Constraints).unwrap();
+        assert_eq!(
+            constraints_rate_8.ark[0][0],
+            field_new!(
+                TestFr,
+                "51456871630395278065627483917901523970718884366549119139144234240744684354360"
+            )
+        );
+        assert_eq!(
+            constraints_rate_8.mds[0][0],
+            field_new!(
+                TestFr,
+                "12929023787467701044434927689422385731071756681420195282613396560814280256210"
+            )
+        );
+
+        // weights
+        let weights_rate_2 = TestFr::get_default_parameters(2, OptimizationGoal::Weight).unwrap();
+        assert_eq!(
+            weights_rate_2.ark[0][0],
+            field_new!(
+                TestFr,
+                "25126470399169474618535500283750950727260324358529540538588217772729895991183"
+            )
+        );
+        assert_eq!(
+            weights_rate_2.mds[0][0],
+            field_new!(
+                TestFr,
+                "46350838805835525240431215868760423854112287760212339623795708191499274188615"
+            )
+        );
+
+        let weights_rate_3 = TestFr::get_default_parameters(3, OptimizationGoal::Weight).unwrap();
+        assert_eq!(
+            weights_rate_3.ark[0][0],
+            field_new!(
+                TestFr,
+                "16345358380711600255519479157621098002794924491287389755192263320486827897573"
+            )
+        );
+        assert_eq!(
+            weights_rate_3.mds[0][0],
+            field_new!(
+                TestFr,
+                "37432344439659887296708509941462699942272362339508052702346957525719991245918"
+            )
+        );
+
+        let weights_rate_4 = TestFr::get_default_parameters(4, OptimizationGoal::Weight).unwrap();
+        assert_eq!(
+            weights_rate_4.ark[0][0],
+            field_new!(
+                TestFr,
+                "2997721997773001075802235431463112417440167809433966871891875582435098138600"
+            )
+        );
+        assert_eq!(
+            weights_rate_4.mds[0][0],
+            field_new!(
+                TestFr,
+                "43959024692079347032841256941012668338943730711936867712802582656046301966186"
+            )
+        );
+
+        let weights_rate_5 = TestFr::get_default_parameters(5, OptimizationGoal::Weight).unwrap();
+        assert_eq!(
+            weights_rate_5.ark[0][0],
+            field_new!(
+                TestFr,
+                "28142027771717376151411984909531650866105717069245696861966432993496676054077"
+            )
+        );
+        assert_eq!(
+            weights_rate_5.mds[0][0],
+            field_new!(
+                TestFr,
+                "13157425078305676755394500322568002504776463228389342308130514165393397413991"
+            )
+        );
+
+        let weights_rate_6 = TestFr::get_default_parameters(6, OptimizationGoal::Weight).unwrap();
+        assert_eq!(
+            weights_rate_6.ark[0][0],
+            field_new!(
+                TestFr,
+                "7417004907071346600696060525974582183666365156576759507353305331252133694222"
+            )
+        );
+        assert_eq!(
+            weights_rate_6.mds[0][0],
+            field_new!(
+                TestFr,
+                "51393878771453405560681338747290999206747890655420330824736778052231938173954"
+            )
+        );
+
+        let weights_rate_7 = TestFr::get_default_parameters(7, OptimizationGoal::Weight).unwrap();
+        assert_eq!(
+            weights_rate_7.ark[0][0],
+            field_new!(
+                TestFr,
+                "47093173418416013663709314805327945458844779999893881721688570889452680883650"
+            )
+        );
+        assert_eq!(
+            weights_rate_7.mds[0][0],
+            field_new!(
+                TestFr,
+                "51455917624412053400160569105425532358410121118308957353565646758865245830775"
+            )
+        );
+
+        let weights_rate_8 = TestFr::get_default_parameters(8, OptimizationGoal::Weight).unwrap();
+        assert_eq!(
+            weights_rate_8.ark[0][0],
+            field_new!(
+                TestFr,
+                "16478680729975035007348178961232525927424769683353433314299437589237598655079"
+            )
+        );
+        assert_eq!(
+            weights_rate_8.mds[0][0],
+            field_new!(
+                TestFr,
+                "39160448583049384229582837387246752222769278402304070376350288593586064961857"
+            )
+        );
+    }
+}

--- a/src/poseidon/traits.rs
+++ b/src/poseidon/traits.rs
@@ -5,14 +5,23 @@ use ark_std::{vec, vec::Vec};
 
 /// An entry in the default Poseidon parameters
 pub struct PoseidonDefaultParametersEntry {
+    /// The rate (in terms of number of field elements).
     pub rate: usize,
+    /// Exponent used in S-boxes.
     pub alpha: usize,
+    /// Number of rounds in a full-round operation.
     pub full_rounds: usize,
+    /// Number of rounds in a partial-round operation.
     pub partial_rounds: usize,
+    /// Number of matrices to skip when generating parameters using the Grain LFSR.
+    ///
+    /// The matrices being skipped are those that do not satisfy all the desired properties.
+    /// See the [reference implementation](https://extgit.iaik.tugraz.at/krypto/hadeshash/-/blob/master/code/generate_parameters_grain.sage) for more detail.
     pub skip_matrices: usize,
 }
 
 impl PoseidonDefaultParametersEntry {
+    /// Create an entry in PoseidonDefaultParameters.
     pub const fn new(
         rate: usize,
         alpha: usize,

--- a/src/poseidon/traits.rs
+++ b/src/poseidon/traits.rs
@@ -136,7 +136,7 @@ impl_poseidon_default_parameters_field!(Fp832, Fp832Parameters);
 mod test {
     use crate::poseidon::{PoseidonDefaultParameters, PoseidonDefaultParametersField};
     use ark_ff::{field_new, fields::Fp256};
-    use ark_ff::{BigInteger256, FftParameters, Fp256Parameters, FpParameters, PrimeField};
+    use ark_ff::{BigInteger256, FftParameters, Fp256Parameters, FpParameters};
     use ark_relations::r1cs::OptimizationGoal;
     use ark_test_curves::bls12_381::FrParameters;
 

--- a/src/poseidon/traits.rs
+++ b/src/poseidon/traits.rs
@@ -3,6 +3,28 @@ use crate::poseidon::PoseidonParameters;
 use ark_ff::{fields::models::*, FpParameters, PrimeField};
 use ark_std::{vec, vec::Vec};
 
+/// An entry in the default Poseidon parameters
+pub struct PoseidonDefaultParametersEntry {
+
+    pub rate: usize,
+    pub alpha: usize,
+    pub full_rounds: usize,
+    pub partial_rounds: usize,
+    pub skip_matrices: usize,
+}
+
+impl PoseidonDefaultParametersEntry {
+    pub const fn new(rate: usize, alpha: usize, full_rounds: usize, partial_rounds: usize, skip_matrices: usize) -> Self {
+        Self {
+            rate,
+            alpha,
+            full_rounds,
+            partial_rounds,
+            skip_matrices
+        }
+    }
+}
+
 /// A trait for default Poseidon parameters associated with a prime field
 pub trait PoseidonDefaultParameters: FpParameters {
     /// An array of the parameters optimized for constraints
@@ -11,12 +33,12 @@ pub trait PoseidonDefaultParameters: FpParameters {
     ///
     /// Here, `skip_matrices` denote how many matrices to skip before
     /// finding one that satisfy all the requirements.
-    const PARAMS_OPT_FOR_CONSTRAINTS: [[usize; 5]; 7];
+    const PARAMS_OPT_FOR_CONSTRAINTS: [PoseidonDefaultParametersEntry; 7];
 
     /// An array of the parameters optimized for weights
     /// (rate, alpha, full_rounds, partial_rounds, skip_matrices)
     /// for rate = 2, 3, 4, 5, 6, 7, 8
-    const PARAMS_OPT_FOR_WEIGHTS: [[usize; 5]; 7];
+    const PARAMS_OPT_FOR_WEIGHTS: [PoseidonDefaultParametersEntry; 7];
 }
 
 /// A field with Poseidon parameters associated
@@ -41,22 +63,22 @@ pub fn get_default_poseidon_parameters_internal<F: PrimeField, P: PoseidonDefaul
     };
 
     for param in params_set.iter() {
-        if param[0] == rate {
+        if param.rate == rate {
             let (ark, mds) = find_poseidon_ark_and_mds::<F>(
                 P::MODULUS_BITS as u64,
                 rate,
-                param[2] as u64,
-                param[3] as u64,
-                param[4] as u64,
+                param.full_rounds as u64,
+                param.partial_rounds as u64,
+                param.skip_matrices as u64,
             );
 
             return Some(PoseidonParameters {
-                full_rounds: param[2],
-                partial_rounds: param[3],
-                alpha: param[1] as u64,
+                full_rounds: param.full_rounds,
+                partial_rounds: param.partial_rounds,
+                alpha: param.alpha as u64,
                 ark,
                 mds,
-                rate: param[0],
+                rate: param.rate,
                 capacity: 1,
             });
         }
@@ -132,7 +154,7 @@ impl_poseidon_default_parameters_field!(Fp832, Fp832Parameters);
 
 #[cfg(test)]
 mod test {
-    use crate::poseidon::{PoseidonDefaultParameters, PoseidonDefaultParametersField};
+    use crate::poseidon::{PoseidonDefaultParameters, PoseidonDefaultParametersField, PoseidonDefaultParametersEntry};
     use ark_ff::{field_new, fields::Fp256};
     use ark_ff::{BigInteger256, FftParameters, Fp256Parameters, FpParameters};
     use ark_test_curves::bls12_381::FrParameters;
@@ -163,23 +185,23 @@ mod test {
     }
 
     impl PoseidonDefaultParameters for TestFrParameters {
-        const PARAMS_OPT_FOR_CONSTRAINTS: [[usize; 5]; 7] = [
-            [2, 17, 8, 31, 0],
-            [3, 5, 8, 56, 0],
-            [4, 5, 8, 56, 0],
-            [5, 5, 8, 57, 0],
-            [6, 5, 8, 57, 0],
-            [7, 5, 8, 57, 0],
-            [8, 5, 8, 57, 0],
+        const PARAMS_OPT_FOR_CONSTRAINTS: [PoseidonDefaultParametersEntry; 7] = [
+            PoseidonDefaultParametersEntry::new(2, 17, 8, 31, 0),
+            PoseidonDefaultParametersEntry::new(3, 5, 8, 56, 0),
+            PoseidonDefaultParametersEntry::new(4, 5, 8, 56, 0),
+            PoseidonDefaultParametersEntry::new(5, 5, 8, 57, 0),
+            PoseidonDefaultParametersEntry::new(6, 5, 8, 57, 0),
+            PoseidonDefaultParametersEntry::new(7, 5, 8, 57, 0),
+            PoseidonDefaultParametersEntry::new(8, 5, 8, 57, 0),
         ];
-        const PARAMS_OPT_FOR_WEIGHTS: [[usize; 5]; 7] = [
-            [2, 257, 8, 13, 0],
-            [3, 257, 8, 13, 0],
-            [4, 257, 8, 13, 0],
-            [5, 257, 8, 13, 0],
-            [6, 257, 8, 13, 0],
-            [7, 257, 8, 13, 0],
-            [8, 257, 8, 13, 0],
+        const PARAMS_OPT_FOR_WEIGHTS: [PoseidonDefaultParametersEntry; 7] = [
+            PoseidonDefaultParametersEntry::new(2, 257, 8, 13, 0),
+            PoseidonDefaultParametersEntry::new(3, 257, 8, 13, 0),
+            PoseidonDefaultParametersEntry::new(4, 257, 8, 13, 0),
+            PoseidonDefaultParametersEntry::new(5, 257, 8, 13, 0),
+            PoseidonDefaultParametersEntry::new(6, 257, 8, 13, 0),
+            PoseidonDefaultParametersEntry::new(7, 257, 8, 13, 0),
+            PoseidonDefaultParametersEntry::new(8, 257, 8, 13, 0),
         ];
     }
 


### PR DESCRIPTION
## Description

This PR is from a branch named `add-rescue`, although this PR did not add Rescue.

It consists of two parts:
1. Cleanup of the Poseidon implementation to better structure the Parameters and the Sponge struct.
2. Add necessary traits and derivations for default Poseidon parameters for each field, which includes Grain LFSR and an aligned parameter generation for Poseidon.

This marks the first step toward the handling of Poseidon parameter generation. 

More changes may show up in separate PRs. This one is long enough and should be concluded.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Wrote unit tests
- [x] Updated relevant documentation in the code
- [x] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
