### PR TITLE
Added padding to Poseidon duplex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Pending
 
+* Added multirate padding to Poseidon duplex
+
 ### Breaking changes
 
 - [\#22](https://github.com/arkworks-rs/sponge/pull/22) Clean up the Poseidon parameter and sponge structures.

--- a/src/poseidon/mod.rs
+++ b/src/poseidon/mod.rs
@@ -456,4 +456,24 @@ mod test {
             )
         );
     }
+
+    // Tests that H(1) != H(1, 0)
+    #[should_panic]
+    #[test]
+    fn test_collision() {
+        let sponge_param = TestFr::get_default_poseidon_parameters(2, false).unwrap();
+
+        let hash1 = {
+            let mut sponge = PoseidonSponge::<TestFr>::new(&sponge_param);
+            sponge.absorb(&vec![TestFr::from(1u8)]);
+            sponge.squeeze_native_field_elements(1)[0]
+        };
+        let hash2 = {
+            let mut sponge = PoseidonSponge::<TestFr>::new(&sponge_param);
+            sponge.absorb(&vec![TestFr::from(1u8), TestFr::from(0u8)]);
+            sponge.squeeze_native_field_elements(1)[0]
+        };
+
+        assert_eq!(hash1, hash2);
+    }
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

The Poseidon duplex construction in this crate was trivially insecure. I wrote a regression test, `test_collision`, that demonstrates two `absorb` inputs which produce the same `squeeze` output. The problem was that there was no padding applied to any absorbed messages.

As mentioned in the [duplex paper](https://keccak.team/files/SpongeDuplex.pdf) a "sponge-compliant" padding scheme (Definition 1) is crucial to the security claims of the sponge and duplex constructions. So I went ahead and adapted the multi-rate padding function (Section 7) to a finite field setting. The only caveat is that this doesn't work when F = Z/2Z. I assume that's not an issue though. If it is, I can make another version that ends up being even less efficient, requiring all Poseidon rates to be at least 3 in order to function.

Two things that still need to be done (and see [Zcash's](https://github.com/zcash/orchard/blob/main/src/primitives/poseidon.rs) impl for a reference):

1. Don't chunk the contents of `absorb` and feed it all in. As the paper specifies,`absorb`'s input len should be limited to the maximum that can fit in a `rate`-sized block, after padding. The current auto-chunking trick makes it so that `absorb(a || b)` and `absorb(a), absorb(b)` yield the same state. This isn't good. Instead, the duplex needs to limit `absorbs` and force the user to figure out message packet system that disambiguates the things that they care about. STROBE disambiguates by prepending every new operation with a special message.

2. Don't allow `squeeze` to output more than `rate` bytes. This is also specified by the paper. I'm actually less confident about this suggestion because it seems fine to simply `permute()` when bytes run out. This is because, by the padding principle, the input will never collide with an actual message. Concretely, this mechanism still satisfies the injectivity claim proven by Lemma 4 in the paper. Also, if this functionality is removed, I'm not certain how one would get more bytes out of a stream.

Finally, I commented out `test_poseidon_sponge_consistency` because I couldn't figure out how to re-derive the new expected values for the output. That's an easy fix if you know which traits give you a base-10 representation of your field elements (which I do not).



---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [X] Targeted PR against correct branch (master)
- [X] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [X] Wrote unit tests
- [X] Updated relevant documentation in the code
- [X] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [X] Re-reviewed `Files changed` in the Github PR explorer
