### PR TITLE
Remove deny(warnings) from crate config.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,8 +11,7 @@
     trivial_casts,
     trivial_numeric_casts,
     unused,
-    variant_size_differences,
-    warnings
+    variant_size_differences
 )]
 #![forbid(unsafe_code)]
 


### PR DESCRIPTION
## Description

While it's useful to disallow warnings in CI, adding `deny(warnings)` to the
crate is actively harmful, as it breaks the code whenever the compiler adds new
warnings.  This has a negative effect on downstream users.  For instance, it's
not currently possible to view the documentation for the current version of the
code, since `cargo doc` fails on a warning about Markdown formatting.

More elaboration can be found here:

https://www.reddit.com/r/rust/comments/f5xpib/psa_denywarnings_is_actively_harmful/

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- ~~[ ] Wrote unit tests~~
- ~~[ ] Updated relevant documentation in the code~~
- ~~[ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`~~
- ~~[ ] Re-reviewed `Files changed` in the Github PR explorer~~
