### PR TITLE
Update the field cast method and serialization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,6 @@ ark-std = { version = "^0.3.0", default-features = false }
 derivative = { version = "2.1.1", features = [ "use_core" ] }
 digest = { version = "0.10.3", default_features = false }
 rand_chacha = { version = "0.3.0", default-features = false }
-num-bigint = { version = "0.4", default-features = false }
 
 # Dependencies for r1cs
 ark-r1cs-std = { version = "^0.3.0", default-features = false, optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ ark-std = { version = "^0.3.0", default-features = false }
 derivative = { version = "2.1.1", features = [ "use_core" ] }
 digest = { version = "0.10.3", default_features = false }
 rand_chacha = { version = "0.3.0", default-features = false }
+num-bigint = { version = "0.4", default-features = false }
 
 # Dependencies for r1cs
 ark-r1cs-std = { version = "^0.3.0", default-features = false, optional = true }

--- a/src/poseidon/mod.rs
+++ b/src/poseidon/mod.rs
@@ -1,5 +1,5 @@
 use crate::{
-    batch_field_cast, squeeze_field_elements_with_sizes_default_impl, Absorb, CryptographicSponge,
+    field_cast, squeeze_field_elements_with_sizes_default_impl, Absorb, CryptographicSponge,
     DuplexSpongeMode, FieldBasedCryptographicSponge, FieldElementSize, SpongeExt,
 };
 use ark_ff::{BigInteger, PrimeField};
@@ -292,7 +292,7 @@ impl<F: PrimeField> CryptographicSponge for PoseidonSponge<F> {
         if F::characteristic() == F2::characteristic() {
             // native case
             let mut buf = Vec::with_capacity(sizes.len());
-            batch_field_cast(
+            field_cast(
                 &self.squeeze_native_field_elements_with_sizes(sizes),
                 &mut buf,
             )
@@ -307,7 +307,7 @@ impl<F: PrimeField> CryptographicSponge for PoseidonSponge<F> {
         if TypeId::of::<F>() == TypeId::of::<F2>() {
             let result = self.squeeze_native_field_elements(num_elements);
             let mut cast = Vec::with_capacity(result.len());
-            batch_field_cast(&result, &mut cast).unwrap();
+            field_cast(&result, &mut cast).unwrap();
             cast
         } else {
             self.squeeze_field_elements_with_sizes::<F2>(


### PR DESCRIPTION
## Description

This PR does two things:
1. We change the field cast to a way that does not require black-box assumptions of the `serialize` function. Now, it relies on `BigInteger` and its le bytes representation.
2. We change `serialize` to `serialize_compressed`. The use of compressed representation is to have some uniqueness guarantees.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Re-reviewed `Files changed` in the Github PR explorer

N/A:
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`